### PR TITLE
Fixes ordering of options in CycleGAN class

### DIFF
--- a/tf2_model.py
+++ b/tf2_model.py
@@ -42,9 +42,9 @@ class CycleGAN(object):
                                         'is_training')
         self.options = OPTIONS._make((args.batch_size,
                                       args.time_step,
-                                      args.pitch_range,
                                       args.input_nc,
                                       args.output_nc,
+                                      args.pitch_range,
                                       args.ngf,
                                       args.ndf,
                                       args.phase == 'train'))


### PR DESCRIPTION
Ordering of the options was wrong, and this causes issues with shape and training. This change let us start training the model.